### PR TITLE
Update node version

### DIFF
--- a/amplify/backend/analytics/chatqlreact/pinpoint-cloudformation-template.json
+++ b/amplify/backend/analytics/chatqlreact/pinpoint-cloudformation-template.json
@@ -200,7 +200,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [

--- a/amplify/backend/analytics/chatqlreact/pinpoint-cloudformation-template.json
+++ b/amplify/backend/analytics/chatqlreact/pinpoint-cloudformation-template.json
@@ -183,7 +183,7 @@
                                 "               Name: appName",
                                 "           }",
                                 "       };",
-                                "       return pinpoint.createApp(params).promise()",
+                                "       pinpoint.createApp(params).promise()",
                                 "           .then((res) => {",
                                 "               responseData = res.ApplicationResponse;",
                                 "               response.send(event, context, response.SUCCESS, responseData);",

--- a/amplify/backend/auth/cognito5a6ec086/cognito5a6ec086-cloudformation-template.yml
+++ b/amplify/backend/auth/cognito5a6ec086/cognito5a6ec086-cloudformation-template.yml
@@ -263,7 +263,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole


### PR DESCRIPTION
AWS Lambda deprecated its runtime support for Node.js 6.10 on April 30th, 2019, and it has started to support Node.js 8.10.  I have changed the appropriate files in the project to conform with the instructions given [here](https://aws-amplify.github.io/docs/cli/lambda-node-version-update).